### PR TITLE
fix: sol 004 Chinese desc.

### DIFF
--- a/puzzles/004.yml
+++ b/puzzles/004.yml
@@ -19,7 +19,7 @@ tuneRevealOffset: 0
 zh-Hans:
   title: 	兔已着陆（兎は舞い降りた）
   author: Zun
-  desc: 东方地灵殿中，1面BOSS清兰的主题曲。
+  desc: 东方绀珠传中，1面BOSS清兰的主题曲。
 en:
   title: The Rabbit Has Landed（兎は舞い降りた）
   author: Zun


### PR DESCRIPTION
题目004中文描述有误，应当将东方地灵殿改为东方绀珠传